### PR TITLE
Asset Share Commons redirect to new location on opensource.adobe.com

### DIFF
--- a/asset-share-commons/index.html
+++ b/asset-share-commons/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+    <title>Redirecting to Asset Share Commons!</title>
+    <description>Asset Share Commons has moved to </description>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;URL='https://opensource.adobe.com/asset-share-commons/'" />
+    <link rel="canonical" href="https://opensource.adobe.com/asset-share-commons/">
+</html>


### PR DESCRIPTION
Added gh-pages redirect to new docs location